### PR TITLE
fix: navigator context issue

### DIFF
--- a/src/lib/components/navigator/navigator.dart
+++ b/src/lib/components/navigator/navigator.dart
@@ -27,13 +27,23 @@ class _NavigatorWidgetState extends State<NavigatorWidget> {
 
   @override
   void initState() {
-    this.pageController = widget.pageController;
+    pageController = widget.pageController;
+    if (pageController.page != null) {
+      currentPage = pageController.page!.round();
+    }
+
     super.initState();
 
-    pageController.addListener(() {
-      currentPage = pageController.page!.round();
-    });
+    pageController.addListener(pageControllerListener);
   }
+
+  @override
+  void dispose() {
+    pageController.removeListener(pageControllerListener);
+    super.dispose();
+  }
+
+  void pageControllerListener() => currentPage = pageController.page!.round();
 
   @override
   Widget build(BuildContext context) {
@@ -79,64 +89,58 @@ class _NavigatorWidgetState extends State<NavigatorWidget> {
             child: child,
           );
         },
-
-        /// Ignore [OverflowError] as widget will transition
-        child: OverflowBox(
-          minHeight: 0,
-          minWidth: 0,
-          child: Container(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                DescribedFeatureOverlay(
+        child: Container(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              DescribedFeatureOverlay(
+                barrierDismissible: false,
+                featureId: "left",
+                overflowMode: OverflowMode.wrapBackground,
+                contentLocation: ContentLocation.above,
+                title: Text("Swipe left to go to the previous page"),
+                tapTarget: Icon(MdiIcons.chevronDoubleLeft),
+                child: Icon(
+                  MdiIcons.chevronDoubleLeft,
+                  color: Colors.grey[700],
+                  size: 30,
+                ),
+              ),
+              DescribedFeatureOverlay(
+                barrierDismissible: false,
+                featureId: "down",
+                overflowMode: OverflowMode.wrapBackground,
+                contentLocation: ContentLocation.above,
+                title: Text("Swipe down to reduce opacity"),
+                tapTarget: Icon(MdiIcons.chevronDoubleDown),
+                child: DescribedFeatureOverlay(
                   barrierDismissible: false,
-                  featureId: "left",
+                  featureId: "up",
                   overflowMode: OverflowMode.wrapBackground,
                   contentLocation: ContentLocation.above,
-                  title: Text("Swipe left to go to the previous page"),
-                  tapTarget: Icon(MdiIcons.chevronDoubleLeft),
+                  title: Text("Swipe up to open the current page"),
+                  tapTarget: Icon(MdiIcons.chevronDoubleUp),
                   child: Icon(
-                    MdiIcons.chevronDoubleLeft,
+                    MdiIcons.chevronDoubleUp,
                     color: Colors.grey[700],
                     size: 30,
                   ),
                 ),
-                DescribedFeatureOverlay(
-                  barrierDismissible: false,
-                  featureId: "down",
-                  overflowMode: OverflowMode.wrapBackground,
-                  contentLocation: ContentLocation.above,
-                  title: Text("Swipe down to reduce opacity"),
-                  tapTarget: Icon(MdiIcons.chevronDoubleDown),
-                  child: DescribedFeatureOverlay(
-                    barrierDismissible: false,
-                    featureId: "up",
-                    overflowMode: OverflowMode.wrapBackground,
-                    contentLocation: ContentLocation.above,
-                    title: Text("Swipe up to open the current page"),
-                    tapTarget: Icon(MdiIcons.chevronDoubleUp),
-                    child: Icon(
-                      MdiIcons.chevronDoubleUp,
-                      color: Colors.grey[700],
-                      size: 30,
-                    ),
-                  ),
+              ),
+              DescribedFeatureOverlay(
+                barrierDismissible: false,
+                featureId: "right",
+                overflowMode: OverflowMode.wrapBackground,
+                contentLocation: ContentLocation.above,
+                title: Text("Swipe right to go to the next page"),
+                tapTarget: Icon(MdiIcons.chevronDoubleRight),
+                child: Icon(
+                  MdiIcons.chevronDoubleRight,
+                  color: Colors.grey[700],
+                  size: 30,
                 ),
-                DescribedFeatureOverlay(
-                  barrierDismissible: false,
-                  featureId: "right",
-                  overflowMode: OverflowMode.wrapBackground,
-                  contentLocation: ContentLocation.above,
-                  title: Text("Swipe right to go to the next page"),
-                  tapTarget: Icon(MdiIcons.chevronDoubleRight),
-                  child: Icon(
-                    MdiIcons.chevronDoubleRight,
-                    color: Colors.grey[700],
-                    size: 30,
-                  ),
-                )
-              ],
-            ),
+              )
+            ],
           ),
         ),
       ),

--- a/src/lib/components/pullback_button/pullback_button.dart
+++ b/src/lib/components/pullback_button/pullback_button.dart
@@ -15,7 +15,6 @@ class _PullableButtonState extends State<PullableButton> {
   late double height, width;
   late double buttonWidth;
   Color _color = Colors.black;
-  bool allowChangingValue = true;
 
   @override
   void initState() {

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -32,7 +32,6 @@ class _MyAppState extends State<MyApp> {
         onGenerateRoute: RouteGenerator.generateRoute,
         debugShowCheckedModeBanner: false,
         home: !firstTime ? NavigatorPage() : WelcomePage(),
-        // home: WelcomePage(),
       ),
     );
   }

--- a/src/lib/pages/navigator/components/horizontal_list.dart
+++ b/src/lib/pages/navigator/components/horizontal_list.dart
@@ -13,10 +13,6 @@ class HorizontalList extends StatefulWidget {
 
 class _HorizontalListState extends State<HorizontalList> {
   late PageController pageController;
-  // int currentPage = 0;
-
-  ValueNotifier<bool> isFadedAway = ValueNotifier(false);
-  bool allowChangingValue = true;
 
   @override
   void initState() {
@@ -43,10 +39,6 @@ class _HorizontalListState extends State<HorizontalList> {
           allowImplicitScrolling: false,
           pageSnapping: true,
           physics: NeverScrollableScrollPhysics(),
-          onPageChanged: (int page) {
-            // currentPage = page;
-            // setState(() {});
-          },
           itemCount: pageList.length,
           controller: pageController,
           itemBuilder: (context, index) {
@@ -55,18 +47,6 @@ class _HorizontalListState extends State<HorizontalList> {
                 return Center(
                   child: PageItem(destination: pageList[index].page),
                 );
-                // double value = 1.0;
-                // if (pageController.position.haveDimensions) {
-                //   value = pageController.page! - index;
-                //   value = (1 - (value.abs() * 0.4)).clamp(0.0, 1.0);
-                // }
-
-                // return Center(
-                //   child: Transform.scale(
-                //     scale: Curves.easeOut.transform(value),
-                //     child: PageItem(destination: pageList[index].page),
-                //   ),
-                // );
               },
             );
           },
@@ -85,7 +65,7 @@ class _HorizontalListState extends State<HorizontalList> {
       child: Hero(
         tag: "herotagfor1",
         child: NavigatorWidget(
-          pageController: this.pageController,
+          pageController: pageController,
         ),
       ),
     );


### PR DESCRIPTION
Fixed, the Navigator losing context issue. Now the navigator, initializes the `currentPage` variable at each rebuild. As it is being called multiple times we have also taken care of disposing off additional listeners.

> Fixes: #14 